### PR TITLE
audit fixes for OFT migration

### DIFF
--- a/src/token/EthfiL2Token.sol
+++ b/src/token/EthfiL2Token.sol
@@ -201,7 +201,6 @@ contract EthfiL2Token is
     function _update(address from, address to, uint256 value)
         internal
         override(ERC20Upgradeable, ERC20VotesUpgradeable)
-        whenNotPaused
     {
         super._update(from, to, value);
     }


### PR DESCRIPTION
I-01

remove the `whenNotPaused` modifier from the token so pause only has the functionality of only pausing the bridging operations